### PR TITLE
DM-32997: Properly deprecate ci_cpp_gen2, and make ci_cpp just run the gen3 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 ``ci_cpp``
 ==========
 
-``ci_cpp`` is a metapackage for the ci_cpp_gen2 and ci_cpp_gen3
-packages, which test the calibration production code in a consistent
-and complete way.  This supplements unit tests in cp_pipe, as it can
-do more computationally expensive tests without slowing down stack
-building.
+``ci_cpp`` is a metapackage for ci_cpp_gen3 package, which tests the
+calibration production code in a consistent and complete way.  This
+supplements unit tests in cp_pipe, as it can do more computationally
+expensive tests without slowing down stack building.
 

--- a/ups/ci_cpp.table
+++ b/ups/ci_cpp.table
@@ -3,7 +3,6 @@
 # - Common third-party packages can be assumed to be recursively included by
 #   the "base" package.
 setupRequired(base)
-setupRequired(ci_cpp_gen2)
 setupRequired(ci_cpp_gen3)
 
 # The following is boilerplate for all packages.


### PR DESCRIPTION
Remove ci_cpp_gen2.